### PR TITLE
Bugfix: Persistent connections not scoped

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.timezynk/mongo "0.6.16"
+(defproject com.timezynk/mongo "0.7.0"
   :description "Clojure wrapper for com.mongodb.client Java API."
   :url "https://github.com/TimeZynk/mongo"
   :license {:name "MIT"

--- a/src/com/timezynk/mongo/util.clj
+++ b/src/com/timezynk/mongo/util.clj
@@ -22,9 +22,6 @@
   (reset! mongo-uri {:uri uri
                      :options options}))
 
-(defn current-uri []
-  @mongo-uri)
-
 (def ^:private connection-map
   (atom {}))
 

--- a/src/com/timezynk/mongo/util.clj
+++ b/src/com/timezynk/mongo/util.clj
@@ -25,12 +25,18 @@
 (defn current-uri []
   @mongo-uri)
 
-(defn ^:no-doc make-connection []
+(def ^:private connection-map
+  (atom {}))
+
+(defn ^:no-doc upsert-connection []
   (let [uri (or @mongo-uri
                 {:uri (System/getenv "MONGO_URI")}
                 (throw (MongoClientException. "Call set-mongo-uri! or define MONGO_URI environment variable prior to calling wrap-mongo")))]
-    (log/info "MongoDB servers" uri)
-    (connection-method (:uri uri) (:options uri))))
+    (or (get @connection-map uri)
+        (let [connection (connection-method (:uri uri) (:options uri))]
+          (log/info "MongoDB servers" uri)
+          (swap! connection-map assoc uri connection)
+          connection))))
 
 (defmacro wrap-mongo
   "Functionally set up or change mongodb connection, using a persistent connection. Reverts to earlier settings when leaving scope.
@@ -58,7 +64,7 @@
    ```"
   {:arglists '([& <body>])}
   [& body]
-  `(let [client# (make-connection)]
+  `(let [client# (upsert-connection)]
      (binding [*mongo-client*   (:client client#)
                *mongo-database* (:database client#)]
        ~@body)))

--- a/test/com/timezynk/mongo/test/persistent_connection.clj
+++ b/test/com/timezynk/mongo/test/persistent_connection.clj
@@ -8,7 +8,7 @@
   (.getName config/*mongo-database*))
 
 (deftest disjoint
-  (testing "Switch to another server after exiting connection scope"
+  (testing "Switch to another database after exiting connection scope"
     (u/set-mongo-uri! "mongodb://localhost:27017/db-1")
     (u/wrap-mongo
       (is (= "db-1" (db-name))))
@@ -17,7 +17,7 @@
       (is (= "db-2" (db-name))))))
 
 (deftest nested
-  (testing "Switch to another server inside the current connection scope"
+  (testing "Switch to another database inside the current connection scope"
     (u/set-mongo-uri! "mongodb://localhost:27017/db-1")
     (u/wrap-mongo
       (is (= "db-1" (db-name)))

--- a/test/com/timezynk/mongo/test/persistent_connection.clj
+++ b/test/com/timezynk/mongo/test/persistent_connection.clj
@@ -1,0 +1,26 @@
+(ns com.timezynk.mongo.test.persistent-connection
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [com.timezynk.mongo.config :as config]
+   [com.timezynk.mongo.util :as u]))
+
+(defn- db-name []
+  (.getName config/*mongo-database*))
+
+(deftest disjoint
+  (testing "Switch to another server after exiting connection scope"
+    (u/set-mongo-uri! "mongodb://localhost:27017/db-1")
+    (u/wrap-mongo
+      (is (= "db-1" (db-name))))
+    (u/set-mongo-uri! "mongodb://localhost:27017/db-2")
+    (u/wrap-mongo
+      (is (= "db-2" (db-name))))))
+
+(deftest nested
+  (testing "Switch to another server inside the current connection scope"
+    (u/set-mongo-uri! "mongodb://localhost:27017/db-1")
+    (u/wrap-mongo
+      (is (= "db-1" (db-name)))
+      (u/set-mongo-uri! "mongodb://localhost:27017/db-2")
+      (u/wrap-mongo
+        (is (= "db-2" (db-name)))))))


### PR DESCRIPTION
Persistent connections don't respect `wrap-mongo` scope.

Notes:
- keeps track of persistent connections
- associates them with the connection URI
- tests re-scoping
- tests nested scopes
